### PR TITLE
Read write labelled data

### DIFF
--- a/R/add_labelled_sheet.R
+++ b/R/add_labelled_sheet.R
@@ -8,6 +8,7 @@
 #' @param sheet_name optional sheet name; if none provided, sheet will be assigned name
 #' of input data set
 #' @param wrkbk workbook object, defaults to wb
+#' @param start_row integer row position where Labels are placed, defaults to 1L
 #'
 #' @return a workbook object
 #' @export
@@ -53,7 +54,7 @@
 #' saveWorkbook(wb, "checkwb.xlsx")
 #'}
 #'
-add_labelled_sheet <- function(data, sheet_name = NULL, wrkbk = wb){
+add_labelled_sheet <- function(data, sheet_name = NULL, wrkbk = wb, start_row = 1L){
 
   # character name of input data
   data_chr <- rlang::as_label(rlang::ensym(data))
@@ -62,8 +63,8 @@ add_labelled_sheet <- function(data, sheet_name = NULL, wrkbk = wb){
   if(is.null(sheet_name)) sheet_name <- data_chr
 
   # exporting when list of data frames supplied
-  if("list" %in% class(data))   purrr::imap(data, ~labelled_sheet(.x, .y, wrkbk))
+  if("list" %in% class(data))   purrr::imap(data, ~labelled_sheet(.x, .y, wrkbk, start_row))
 
   # exporting when single data frame supplied
-  if("data.frame" %in% class(data))  labelled_sheet(data, sheet_name, wrkbk)
+  if("data.frame" %in% class(data))  labelled_sheet(data, sheet_name, wrkbk, start_row)
 }

--- a/R/find_duplicates.R
+++ b/R/find_duplicates.R
@@ -18,12 +18,18 @@ find_duplicates <- function(data, id) {
   #  usethis::ui_stop("{id} is not in the data set.")
   #}
 
-  data |>
-    dplyr::group_by({{id}}) |>
-    dplyr::add_count() |>
-    dplyr::ungroup() |>
-    dplyr::filter(n > 1) |>
-    dplyr::select({{id}}, num_obs = n) |>
+  # data |>
+  #   dplyr::group_by({{id}}) |>
+  #   dplyr::add_count() |>
+  #   dplyr::ungroup() |>
+  #   dplyr::filter(n > 1) |>
+  #   dplyr::select({{id}}, num_obs = n) |>
+  #   dplyr::distinct()
+
+  data %>%
+    dplyr::add_count({{id}}, name = "n") %>%
+    dplyr::filter(n > 1) %>%
+    dplyr::select({{id}}, num_obs = n) %>%
     dplyr::distinct()
 }
 

--- a/R/labelled_sheet.R
+++ b/R/labelled_sheet.R
@@ -7,6 +7,7 @@
 #' @param sheet_name optional sheet name; if none provided, sheet will be assigned name
 #' of input data set
 #' @param wrkbk workbook name, defaults to wb
+#' @param start_row integer row position where the labels must be placed, `data` is placed at start_row+1, defaults to 1L
 #'
 #' @return a workbook object
 #'
@@ -27,7 +28,7 @@
 #' wb <- labelled_sheet(dat_labelled, sheet_name = "example sheet", wrkbk = wb)
 #' saveWorkbook(wb, "checkwb.xlsx")
 #'}
-labelled_sheet <- function(data, sheet_name = NULL, wrkbk = wb){
+labelled_sheet <- function(data, sheet_name = NULL, wrkbk = wb, start_row = 1L){
 
   # ----------------------------------------------------------------------------
   # global settings and preferences - where should these go?
@@ -55,16 +56,16 @@ labelled_sheet <- function(data, sheet_name = NULL, wrkbk = wb){
 
   # export data as an Excel-formatted Table starting at row 2
   openxlsx::writeDataTable(wrkbk, sheet = sheet_name, x = data, colNames = TRUE,
-                           startRow = 2, withFilter=TRUE,
+                           startRow = start_row + 1, withFilter=TRUE,
                            tableStyle = "TableStyleLight8") # This table style is default white rows with dark headers
 
-  # export labels to rows 1
-  openxlsx::writeData(wrkbk, sheet = sheet_name, x = var_labels, colNames = FALSE)
+  # export labels to start_row
+  openxlsx::writeData(wrkbk, sheet = sheet_name, x = var_labels, colNames = FALSE, startRow = start_row )
 
-  # add freeze pane on rows 1 and 2
-  openxlsx::freezePane(wrkbk, sheet = sheet_name, firstActiveRow = 3)
+  # add freeze pane on start_row and start_row + 1 rows
+  openxlsx::freezePane(wrkbk, sheet = sheet_name, firstActiveRow = start_row+2)
 
   # add style to labels
-  openxlsx::addStyle(wrkbk, sheet = sheet_name, rows = 1, cols = 1:length(var_labels), style = hs1)
+  openxlsx::addStyle(wrkbk, sheet = sheet_name, rows = start_row, cols = 1:length(var_labels), style = hs1)
 
 }

--- a/R/read_labelled_sheet.R
+++ b/R/read_labelled_sheet.R
@@ -6,6 +6,7 @@
 #' @param sheet name of sheet to import
 #' @param date_detect regex expression indicating variables to be imported
 #' as dates
+#' @param start_row integer row position where labels are placed, defaults to 1L
 #'
 #' @return a tibble
 #' @export
@@ -18,10 +19,10 @@
 #'   date_detect = "cyc1_visdat|cyc2_visdat"
 #')
 #'}
-read_labelled_sheet <- function(path, sheet, date_detect = NULL){
+read_labelled_sheet <- function(path, sheet, date_detect = NULL, start_row = 1L){
 
   # data frame with variable labels and single row containing variable names
-  dat_header <- readxl::read_excel(path = path, sheet = sheet, n_max = 1)
+  dat_header <- readxl::read_excel(path = path, sheet = sheet, n_max = 1, skip = start_row - 1)
 
   # variable labels
   dat_labels <- colnames(dat_header)
@@ -42,7 +43,7 @@ read_labelled_sheet <- function(path, sheet, date_detect = NULL){
   dat <- readxl::read_excel(
     path = path,
     sheet = sheet,
-    skip = 1,
+    skip = start_row,
     col_types = variable_types
   )
 

--- a/man/add_labelled_sheet.Rd
+++ b/man/add_labelled_sheet.Rd
@@ -4,7 +4,7 @@
 \alias{add_labelled_sheet}
 \title{Adds a sheet to an excel workbook with with both variable names and labels.}
 \usage{
-add_labelled_sheet(data, sheet_name = NULL, wrkbk = wb)
+add_labelled_sheet(data, sheet_name = NULL, wrkbk = wb, start_row = 1L)
 }
 \arguments{
 \item{data}{labelled data to add to sheet. can accept named list or data frame.}
@@ -13,6 +13,8 @@ add_labelled_sheet(data, sheet_name = NULL, wrkbk = wb)
 of input data set}
 
 \item{wrkbk}{workbook object, defaults to wb}
+
+\item{start_row}{integer row position where Labels are placed, defaults to 1L}
 }
 \value{
 a workbook object

--- a/man/labelled_sheet.Rd
+++ b/man/labelled_sheet.Rd
@@ -4,7 +4,7 @@
 \alias{labelled_sheet}
 \title{A hidden function to add labelled data sheet to an excel workbook through openxlsx}
 \usage{
-labelled_sheet(data, sheet_name = NULL, wrkbk = wb)
+labelled_sheet(data, sheet_name = NULL, wrkbk = wb, start_row = 1L)
 }
 \arguments{
 \item{data}{labelled data to add to sheet}
@@ -13,6 +13,8 @@ labelled_sheet(data, sheet_name = NULL, wrkbk = wb)
 of input data set}
 
 \item{wrkbk}{workbook name, defaults to wb}
+
+\item{start_row}{integer row position where the labels must be placed, \code{data} is placed at start_row+1, defaults to 1L}
 }
 \value{
 a workbook object

--- a/man/read_labelled_sheet.Rd
+++ b/man/read_labelled_sheet.Rd
@@ -4,7 +4,7 @@
 \alias{read_labelled_sheet}
 \title{Reads an excel sheet with labelled data}
 \usage{
-read_labelled_sheet(path, sheet, date_detect = NULL)
+read_labelled_sheet(path, sheet, date_detect = NULL, start_row = 1L)
 }
 \arguments{
 \item{path}{to the xls/xlsx file, including data set name and extension}
@@ -13,6 +13,8 @@ read_labelled_sheet(path, sheet, date_detect = NULL)
 
 \item{date_detect}{regex expression indicating variables to be imported
 as dates}
+
+\item{start_row}{integer row position where labels are placed, defaults to 1L}
 }
 \value{
 a tibble

--- a/tests/testthat/test-read_labelled_sheet_works.R
+++ b/tests/testthat/test-read_labelled_sheet_works.R
@@ -24,4 +24,19 @@ test_that("read_labelled_sheet gives same output as input data", {
   expect_equal(unname(labelled::var_label(input_df, unlist = TRUE)),
                unname(labelled::var_label(output_df, unlist = TRUE)))
 
+  # To test that labels starting from rows other than 1 also works
+  wb <- openxlsx::createWorkbook()
+  add_labelled_sheet(input_df, wb, sheet_name = "example sheet", start_row = 2L)
+  openxlsx::saveWorkbook(wb, "checkwb2.xlsx", overwrite = TRUE)
+
+  output_df <- read_labelled_sheet("checkwb2.xlsx", sheet = "example sheet", start_row = 2L)
+  unlink("checkwb2.xlsx")
+
+  # Column Names are same
+  expect_equal(colnames(input_df),colnames(output_df))
+
+  # Labels are same
+  expect_equal(unname(labelled::var_label(input_df, unlist = TRUE)),
+               unname(labelled::var_label(output_df, unlist = TRUE)))
+
 })


### PR DESCRIPTION
Made changes to `add_labelled_sheet`, `labelled_sheet` and `read_labelled_sheet` functions to allow for writing to/reading from rows other than 1. All existing usage will continue to work as required as the new `start_row` argument has default value of 1L. Added new tests and All tests pass.